### PR TITLE
Fix Main and PR Preview builds

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -31,9 +31,24 @@ jobs:
         env:
           JEKYLL_ENV: production
 
+      - name: Checkout existing gh-pages branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          path: old-gh-pages
+          continue-on-error: trusted
+
+      - name: Persist PR Previews
+        run: |
+          if [ -d "old-gh-pages/pr-preview" ]; then
+            cp -r old-gh-pages/pr-preview ./_site/pr-preview
+            echo "Successfully persisted PR previews!"
+          else
+            echo "No PR previews found to persist."
+          fi
+
       - name: Deploy to gh-pages branch
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_site
-          keep_files: true # CRITICAL

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,20 +6,18 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to push the built site to the gh-pages branch
+
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -27,28 +25,15 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
 
-      - name: Setup GitHub Pages
-        id: pages
-        uses: actions/configure-pages@v5
-
       - name: Build with Jekyll
         # Uses the base_path output from the setup step to ensure links work
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: _site/
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          keep_files: true # CRITICAL

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -6,15 +6,15 @@ on:
     branches:
       - main
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required to push the built site to the gh-pages branch
+
+    concurrency:
+      group: "pages-deploy-queue" # Must match deploy in pr-preview.yaml!
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -8,29 +8,53 @@ on:
       - synchronize
       - closed
 
-concurrency: preview-${{ github.ref }}
-
 jobs:
-  pr-preview:
+  build-pr-preview:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    if: github.event.action != 'closed'
+    concurrency:
+      group: pr-preview-build-${{ github.event.number }}
+      cancel-in-progress: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Ruby
-        if: github.event.action != 'closed'
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
 
       - name: Build Jekyll site
-        if: github.event.action != 'closed'
         # Builds the site natively to the _site/ directory and dynamically sets the baseurl
         run: bundle exec jekyll build --baseurl /${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: preview-site-${{ github.event.number }}
+          path: _site/
+
+  deploy-pr-preview:
+    needs: build-pr-preview
+    runs-on: ubuntu-latest
+    if: ${{ always() && (needs.build-pr-preview.result == 'success' || github.event.action == 'closed') }}
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: "pages-deploy-queue" # Must match github-pages.yml!
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download Artifact
+        if: github.event.action != 'closed'
+        uses: actions/download-artifact@v8`
+        with:
+          name: preview-site-${{ github.event.number }}
+          path: _site/
 
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1

--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Download Artifact
         if: github.event.action != 'closed'
-        uses: actions/download-artifact@v8`
+        uses: actions/download-artifact@v8
         with:
           name: preview-site-${{ github.event.number }}
           path: _site/


### PR DESCRIPTION
Fix it - Currently main builds idon't work

Whoops, Gemini trap that I missed. It switched the main branch workflow to not use gh-pages, but if I switch settings for that to work, PR previews will break. Did some research and it seems the gh-pages approach really is the only way to get PR previews.

Also copy PR Previews when doing a main rebuild so we can wipe the prior main build and don't end up with orphaned files

Also fix concurrency so PR previews don't get lost